### PR TITLE
Browser runner fixes and honest benchmarks

### DIFF
--- a/fusor/fusor-conformance/Cargo.toml
+++ b/fusor/fusor-conformance/Cargo.toml
@@ -35,3 +35,13 @@ pollster.workspace = true
 [[bin]]
 name = "fusor-conformance"
 path = "src/main.rs"
+
+# The fusor-versus-burn table the browser page shows, on the native device.
+[[example]]
+name = "bench_compare"
+required-features = ["burn-bench"]
+
+[[example]]
+name = "bench_sweep"
+required-features = ["burn-bench"]
+

--- a/fusor/fusor-conformance/examples/bench_compare.rs
+++ b/fusor/fusor-conformance/examples/bench_compare.rs
@@ -1,0 +1,55 @@
+//! Run the benchmark registry on the native device and print each case's
+//! fusor-versus-burn ratio, so the comparison the browser page shows can be
+//! checked without a browser.
+
+use fusor::Device;
+use fusor_conformance::bench::{BenchmarkConfig, BenchmarkEvent, BenchmarkReport, registry};
+
+fn main() {
+    pollster::block_on(async {
+        let device = Device::gpu().await.expect("a gpu device");
+        let filter = std::env::args().nth(1);
+        let cases = registry::cases()
+            .into_iter()
+            .filter(|c| {
+                filter
+                    .as_ref()
+                    .is_none_or(|f| c.name().contains(f.as_str()))
+            })
+            .collect::<Vec<_>>();
+        let mut reports: Vec<BenchmarkReport> = Vec::new();
+        registry::run_cases(&device, BenchmarkConfig::default(), cases, |event| {
+            if let BenchmarkEvent::Finished(report) = event {
+                println!("{:<52} {:>9.3} ms", report.name, report.mean_ms);
+                reports.push(report);
+            }
+        })
+        .await
+        .expect("the benchmark suite");
+
+        println!(
+            "\n{:<44} {:>9} {:>9} {:>10}",
+            "case", "burn ms", "fusor ms", "ratio"
+        );
+        for report in &reports {
+            let Some((suite, case)) = report.name.split_once("::") else {
+                continue;
+            };
+            if suite != "webgpu" {
+                continue;
+            }
+            let Some(burn) = reports.iter().find(|r| r.name == format!("burn::{case}")) else {
+                continue;
+            };
+            // Medians, for the reason the page's own comparison gives: a
+            // first-round warmup outlier drags a mean into fiction.
+            let ratio = burn.median_ms / report.median_ms;
+            let word = if ratio >= 1.0 { "faster" } else { "slower" };
+            let shown = if ratio >= 1.0 { ratio } else { 1.0 / ratio };
+            println!(
+                "{case:<44} {:>9.3} {:>9.3} {shown:>7.2}x {word}",
+                burn.median_ms, report.median_ms
+            );
+        }
+    });
+}

--- a/fusor/fusor-conformance/examples/bench_sweep.rs
+++ b/fusor/fusor-conformance/examples/bench_sweep.rs
@@ -1,0 +1,35 @@
+//! One benchmark's size sweep on the native device: burn and fusor medians
+//! side by side at every size, which is what shows whether either side's
+//! number tracks the problem or sits at a fixed floor.
+
+use fusor::Device;
+use fusor_conformance::bench::{BenchmarkConfig, sweep};
+
+fn main() {
+    pollster::block_on(async {
+        let device = Device::gpu().await.expect("a gpu device");
+        let case = std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| "elementwise_add_square".to_string());
+        let points = sweep::run_sweep(&case, &device, BenchmarkConfig::new(2, 3, 5), |_| {})
+            .await
+            .expect("the sweep");
+        println!(
+            "{:<14} {:>10} {:>12} {:>12}",
+            "size", "elements", "burn ms", "fusor ms"
+        );
+        for point in &points {
+            println!(
+                "{:<14} {:>10} {:>12.3} {:>12.3}",
+                point.label,
+                point.value,
+                point.burn.as_ref().map(|r| r.median_ms).unwrap_or(f64::NAN),
+                point
+                    .webgpu
+                    .as_ref()
+                    .map(|r| r.median_ms)
+                    .unwrap_or(f64::NAN),
+            );
+        }
+    });
+}

--- a/fusor/fusor-conformance/src/bench/burn.rs
+++ b/fusor/fusor-conformance/src/bench/burn.rs
@@ -91,6 +91,27 @@ async fn materialize<const R: usize>(tensor: BurnTensor<R>) -> BenchmarkResult<(
     Ok(())
 }
 
+/// Hand one round's tensors to the timing loop. Burn is lazy, so an
+/// iteration is the op stream this builds; `flush` is what makes it run.
+async fn queue<const R: usize>(tensor: BurnTensor<R>) -> BenchmarkResult<BurnTensor<R>> {
+    Ok(tensor)
+}
+
+/// Run everything the round queued and bring one result back.
+///
+/// Reading the last tensor forces the whole round: burn does not skip the
+/// results nobody reads (an unread 2048-square matmul still costs its 4.8 ms),
+/// and every tensor stays alive until after the download, so none of them can
+/// be dropped before it runs.
+async fn flush<const R: usize>(outputs: Vec<BurnTensor<R>>) -> BenchmarkResult<()> {
+    let Some(last) = outputs.last().cloned() else {
+        return Ok(());
+    };
+    let _ = last.into_data_async().await;
+    drop(outputs);
+    Ok(())
+}
+
 async fn values_input<const R: usize>(
     device: &WgpuDevice,
     shape: [usize; R],
@@ -133,10 +154,14 @@ pub(super) async fn elementwise_add_square_case(
     let shape = [size, size];
     let lhs = input_tensor(&device, shape, 1, 0.01).await?;
     let rhs = input_tensor(&device, shape, 2, 0.008).await?;
-    let samples = time_samples(config, || {
-        let output = lhs.clone() + rhs.clone();
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = lhs.clone() + rhs.clone();
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -154,10 +179,14 @@ pub(super) async fn elementwise_mul_rank4_case(
     let device = initialized_device().await;
     let lhs = input_tensor(&device, shape, 3, 0.012).await?;
     let rhs = input_tensor(&device, shape, 4, 0.009).await?;
-    let samples = time_samples(config, || {
-        let output = lhs.clone() * rhs.clone();
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = lhs.clone() * rhs.clone();
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -175,10 +204,14 @@ pub(super) async fn unary_trig_chain_case(
     let device = initialized_device().await;
     let shape = [size, size];
     let input = input_tensor(&device, shape, 10, 0.01).await?;
-    let samples = time_samples(config, || {
-        let output = input.clone().sin() + input.clone().cos();
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = input.clone().sin() + input.clone().cos();
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -195,10 +228,14 @@ pub(super) async fn activation_gelu_case(
 ) -> BenchmarkResult<BenchmarkReport> {
     let device = initialized_device().await;
     let input = input_tensor(&device, shape, 11, 0.015).await?;
-    let samples = time_samples(config, || {
-        let output = activation::gelu(input.clone());
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = activation::gelu(input.clone());
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -218,10 +255,14 @@ pub(super) async fn broadcast_add_case(
     let vector_shape = [512usize];
     let matrix = input_tensor(&device, matrix_shape, 12, 0.006).await?;
     let vector = input_tensor(&device, vector_shape, 13, 0.01).await?;
-    let samples = time_samples(config, || {
-        let output = matrix.clone() + vector.clone().reshape([1, vector_shape[0]]);
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = matrix.clone() + vector.clone().reshape([1, vector_shape[0]]);
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -238,11 +279,15 @@ pub(super) async fn transpose_then_elementwise_case(
 ) -> BenchmarkResult<BenchmarkReport> {
     let device = initialized_device().await;
     let input = input_tensor(&device, shape, 14, 0.01).await?;
-    let samples = time_samples(config, || {
-        let transposed = input.clone().transpose();
-        let output = transposed.clone() * transposed;
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let transposed = input.clone().transpose();
+            let output = transposed.clone() * transposed;
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -260,10 +305,14 @@ pub(super) async fn reduction_sum_last_dim_case(
     let device = initialized_device().await;
     let shape = [rows, 512usize];
     let input = input_tensor(&device, shape, 15, 0.004).await?;
-    let samples = time_samples(config, || {
-        let output = input.clone().sum_dim(1);
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = input.clone().sum_dim(1);
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -280,10 +329,14 @@ pub(super) async fn reduction_max_middle_axis_case(
 ) -> BenchmarkResult<BenchmarkReport> {
     let device = initialized_device().await;
     let input = input_tensor(&device, shape, 16, 0.004).await?;
-    let samples = time_samples(config, || {
-        let output = input.clone().max_dim(1);
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = input.clone().max_dim(1);
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -301,10 +354,14 @@ pub(super) async fn softmax_last_dim_case(
     let device = initialized_device().await;
     let shape = [rows, 256usize];
     let input = input_tensor(&device, shape, 5, 0.006).await?;
-    let samples = time_samples(config, || {
-        let output = activation::softmax(input.clone(), 1);
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = activation::softmax(input.clone(), 1);
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -321,10 +378,14 @@ pub(super) async fn softmax_middle_axis_case(
 ) -> BenchmarkResult<BenchmarkReport> {
     let device = initialized_device().await;
     let input = input_tensor(&device, shape, 17, 0.004).await?;
-    let samples = time_samples(config, || {
-        let output = activation::softmax(input.clone(), 1);
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = activation::softmax(input.clone(), 1);
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -345,10 +406,14 @@ pub(super) async fn layer_norm_last_dim_case(
     let layer = LayerNormConfig::new(last_dim)
         .with_epsilon(1.0e-5)
         .init::<Wgpu>(&device);
-    let samples = time_samples(config, || {
-        let output = layer.clone().forward(input.clone());
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = layer.clone().forward(input.clone());
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -369,10 +434,14 @@ pub(super) async fn rms_norm_fused_case(
     let rms = RmsNormConfig::new(last_dim)
         .with_epsilon(1.0e-5)
         .init::<Wgpu>(&device);
-    let samples = time_samples(config, || {
-        let output = rms.clone().forward(input.clone());
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = rms.clone().forward(input.clone());
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -392,10 +461,14 @@ pub(super) async fn dense_matmul_square_case(
     let rhs_shape = [size, size];
     let lhs = input_tensor(&device, lhs_shape, 6, 0.004).await?;
     let rhs = input_tensor(&device, rhs_shape, 7, 0.004).await?;
-    let samples = time_samples(config, || {
-        let output = lhs.clone().matmul(rhs.clone());
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = lhs.clone().matmul(rhs.clone());
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -421,10 +494,14 @@ pub(super) async fn dense_batched_matmul_case(
     let rhs_shape = [batch, k, m];
     let lhs = input_tensor(&device, lhs_shape, 23, 0.004).await?;
     let rhs = input_tensor(&device, rhs_shape, 24, 0.004).await?;
-    let samples = time_samples(config, || {
-        let output = lhs.clone().matmul(rhs.clone());
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = lhs.clone().matmul(rhs.clone());
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -450,15 +527,19 @@ pub(super) async fn conv1d_small_case(
     let input = input_tensor(&device, input_shape, 25, 0.01).await?;
     let weight = input_tensor(&device, weight_shape, 26, 0.01).await?;
     let bias = input_tensor(&device, bias_shape, 27, 0.001).await?;
-    let samples = time_samples(config, || {
-        let output = module::conv1d(
-            input.clone(),
-            weight.clone(),
-            Some(bias.clone()),
-            ConvOptions::new([2], [1], [1], 1),
-        );
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = module::conv1d(
+                input.clone(),
+                weight.clone(),
+                Some(bias.clone()),
+                ConvOptions::new([2], [1], [1], 1),
+            );
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -481,10 +562,14 @@ pub(super) async fn top_k_case(
 ) -> BenchmarkResult<BenchmarkReport> {
     let device = initialized_device().await;
     let input = values_input(&device, [input_len], values).await?;
-    let samples = time_samples(config, || {
-        let output = input.clone().topk(k, 0);
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = input.clone().topk(k, 0);
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -507,10 +592,14 @@ pub(super) async fn qgemv_dense_case(
     let dense_weight_shape = [weight_shape[1], weight_shape[0]];
     let input = input_tensor(&device, input_shape, input_seed, 0.003).await?;
     let weights = input_tensor(&device, dense_weight_shape, weight_seed, 0.003).await?;
-    let samples = time_samples(config, || {
-        let output = input.clone().matmul(weights.clone());
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = input.clone().matmul(weights.clone());
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -536,13 +625,17 @@ pub(super) async fn q4k_paired_silu_case(
     let pair_len = weight_shape[0] / 2;
     let input = input_tensor(&device, input_shape, 30, 0.003).await?;
     let weights = input_tensor(&device, dense_weight_shape, 82, 0.003).await?;
-    let samples = time_samples(config, || {
-        let projected = input.clone().matmul(weights.clone());
-        let gate = projected.clone().narrow(1, 0, pair_len);
-        let up = projected.narrow(1, pair_len, pair_len);
-        let output = activation::silu(gate) * up;
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let projected = input.clone().matmul(weights.clone());
+            let gate = projected.clone().narrow(1, 0, pair_len);
+            let up = projected.narrow(1, pair_len, pair_len);
+            let output = activation::silu(gate) * up;
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -569,21 +662,25 @@ pub(super) async fn attention_case(
     let q = input_tensor(&device, shape, seeds[0], 0.003).await?;
     let k = input_tensor(&device, shape, seeds[1], 0.003).await?;
     let v = input_tensor(&device, shape, seeds[2], 0.003).await?;
-    let samples = time_samples(config, || {
-        let output = module::attention(
-            q.clone(),
-            k.clone(),
-            v.clone(),
-            None,
-            None,
-            AttentionModuleOptions {
-                scale: Some(1.0 / (64.0f64).sqrt()),
-                softcap: None,
-                is_causal: causal,
-            },
-        );
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = module::attention(
+                q.clone(),
+                k.clone(),
+                v.clone(),
+                None,
+                None,
+                AttentionModuleOptions {
+                    scale: Some(1.0 / (64.0f64).sqrt()),
+                    softcap: None,
+                    is_causal: causal,
+                },
+            );
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,
@@ -603,10 +700,14 @@ pub(super) async fn rope_fused_decode_case(
     let [_, _, _, head_dim] = shape;
     let input = input_tensor(&device, shape, 9, 0.01).await?;
     let rope = RotaryEncodingConfig::new(seq_len * 2, head_dim).init::<Wgpu>(&device);
-    let samples = time_samples(config, || {
-        let output = rope.clone().forward(input.clone());
-        async move { materialize(output).await }
-    })
+    let samples = time_samples(
+        config,
+        || {
+            let output = rope.clone().forward(input.clone());
+            async move { queue(output).await }
+        },
+        flush,
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,

--- a/fusor/fusor-conformance/src/bench/mod.rs
+++ b/fusor/fusor-conformance/src/bench/mod.rs
@@ -55,12 +55,12 @@ impl BenchmarkConfig {
 }
 
 impl Default for BenchmarkConfig {
-    /// Ten iterations to a round, because one download closes a round and
-    /// burn's costs about 35 ms however small the tensor is: at three
-    /// iterations that latency is still a third of what a cheap case
-    /// reports, and at ten it is a few percent.
+    /// The iteration count here is only calibration's starting guess (see
+    /// [`time_samples`]); nine rounds is what the reported median rests on,
+    /// which holds the run-to-run spread near ten percent for about eight
+    /// seconds of page time.
     fn default() -> Self {
-        Self::new(2, 10, 5)
+        Self::new(2, 10, 9)
     }
 }
 
@@ -81,17 +81,27 @@ pub struct BenchmarkReport {
     pub detail: String,
 }
 
+/// What one case's timed rounds produced: the rounds themselves and how many
+/// iterations each of them held, which calibration decides rather than the
+/// config (see [`time_samples`]).
+pub(crate) struct TimedRounds {
+    pub(crate) rounds: Vec<Duration>,
+    pub(crate) iterations: usize,
+}
+
 impl BenchmarkReport {
     pub(crate) fn new(
         name: impl Into<String>,
         config: BenchmarkConfig,
-        samples: Vec<Duration>,
+        timed: TimedRounds,
         detail: impl Into<String>,
     ) -> Self {
         let config = config.sanitized();
+        let iterations = timed.iterations.max(1);
+        let samples = timed.rounds;
         let mut sample_mean_ms = samples
             .iter()
-            .map(|elapsed| elapsed.as_secs_f64() * 1000.0 / config.iterations as f64)
+            .map(|elapsed| elapsed.as_secs_f64() * 1000.0 / iterations as f64)
             .collect::<Vec<_>>();
         let total_ms = samples
             .iter()
@@ -103,11 +113,11 @@ impl BenchmarkReport {
         let min_ms = sample_mean_ms.first().copied().unwrap_or(0.0);
         let max_ms = sample_mean_ms.last().copied().unwrap_or(0.0);
         let stddev_ms = stddev(&sample_mean_ms, mean_ms);
-        let total_iterations = config.iterations * config.samples;
+        let total_iterations = iterations * samples.len();
         Self {
             name: name.into(),
             warmups: config.warmups,
-            iterations: config.iterations,
+            iterations,
             samples: config.samples,
             total_iterations,
             sample_mean_ms,
@@ -192,11 +202,42 @@ impl BenchmarkCase {
 /// iteration *started*; `flush` makes the round's results real, and holds
 /// every one of them alive until it does, so neither library can skip the
 /// results nobody asked for.
+/// How long a timed round should take. A browser clamps `performance.now()`
+/// to 100 microseconds, so a round of a few hundred microseconds is only a
+/// handful of ticks and quantization alone moved these cases by 3x between
+/// runs. Twenty milliseconds is two hundred ticks, which puts the clock's
+/// contribution near a half percent.
+const TARGET_ROUND_MS: f64 = 20.0;
+
+/// Ceiling on a calibrated round. A round holds every iteration's output
+/// alive until it flushes, so the count is also how many results sit on the
+/// device at once: at a megabyte an output, a few hundred is already a few
+/// hundred megabytes. The cheapest cases hit this and settle for a shorter
+/// round, which still clears the clock by a wide margin.
+const MAX_ITERATIONS: usize = 256;
+
+/// Time `samples` rounds, each of enough iterations to outrun the clock, and
+/// close every round with one `flush`.
+///
+/// **Rounds, not iterations, are timed.** Retrieving a result costs each
+/// library a fixed latency unrelated to the kernels — burn's is about 35 ms —
+/// so a suite that downloaded every iteration reported that latency for every
+/// case, and a 128x128 add measured the same as a 2048x2048 matmul.
+///
+/// **The iteration count is calibrated, not configured.** `config.iterations`
+/// is the starting guess; one unrecorded round measures the case and the
+/// count is rescaled so a timed round lands near [`TARGET_ROUND_MS`]. Without
+/// it the cheap cases sat under the browser's timer resolution and their
+/// numbers were noise.
+///
+/// `run_once` only has to get an iteration started; `flush` makes the round's
+/// results real and holds every one of them alive until it does, so neither
+/// library can skip the results nobody asked for.
 pub(crate) async fn time_samples<F, Fut, T, G, GFut>(
     config: BenchmarkConfig,
     mut run_once: F,
     mut flush: G,
-) -> BenchmarkResult<Vec<Duration>>
+) -> BenchmarkResult<TimedRounds>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = BenchmarkResult<T>>,
@@ -204,23 +245,34 @@ where
     GFut: Future<Output = BenchmarkResult<()>>,
 {
     let config = config.sanitized();
-    if config.warmups > 0 {
-        let mut warm = Vec::with_capacity(config.warmups);
-        for _ in 0..config.warmups {
-            warm.push(run_once().await?);
+    let round = async |n: usize, run_once: &mut F, flush: &mut G| -> BenchmarkResult<Duration> {
+        let started = Instant::now();
+        let mut held = Vec::with_capacity(n);
+        for _ in 0..n {
+            held.push(run_once().await?);
         }
-        flush(warm).await?;
+        flush(held).await?;
+        Ok(started.elapsed())
+    };
+
+    for _ in 0..config.warmups {
+        round(config.iterations, &mut run_once, &mut flush).await?;
     }
 
-    let mut samples = Vec::with_capacity(config.samples);
+    // Calibrate off a round nobody records: whatever the case costs, the
+    // timed rounds should be long enough to measure.
+    let probe = round(config.iterations, &mut run_once, &mut flush).await?;
+    let per_iteration_ms = probe.as_secs_f64() * 1000.0 / config.iterations as f64;
+    let iterations = if per_iteration_ms > 0.0 {
+        ((TARGET_ROUND_MS / per_iteration_ms).ceil() as usize)
+            .clamp(config.iterations, MAX_ITERATIONS)
+    } else {
+        MAX_ITERATIONS
+    };
+
+    let mut rounds = Vec::with_capacity(config.samples);
     for _ in 0..config.samples {
-        let started = Instant::now();
-        let mut round = Vec::with_capacity(config.iterations);
-        for _ in 0..config.iterations {
-            round.push(run_once().await?);
-        }
-        flush(round).await?;
-        samples.push(started.elapsed());
+        rounds.push(round(iterations, &mut run_once, &mut flush).await?);
     }
-    Ok(samples)
+    Ok(TimedRounds { rounds, iterations })
 }

--- a/fusor/fusor-conformance/src/bench/mod.rs
+++ b/fusor/fusor-conformance/src/bench/mod.rs
@@ -55,8 +55,12 @@ impl BenchmarkConfig {
 }
 
 impl Default for BenchmarkConfig {
+    /// Ten iterations to a round, because one download closes a round and
+    /// burn's costs about 35 ms however small the tensor is: at three
+    /// iterations that latency is still a third of what a cheap case
+    /// reports, and at ten it is a few percent.
     fn default() -> Self {
-        Self::new(2, 3, 7)
+        Self::new(2, 10, 5)
     }
 }
 
@@ -176,25 +180,46 @@ impl BenchmarkCase {
     }
 }
 
-pub(crate) async fn time_samples<F, Fut>(
+/// Time `samples` rounds of `iterations` computations, each round ending in
+/// one `flush`.
+///
+/// The flush is per round, never per iteration, and that is the whole point.
+/// Retrieving a result costs each library a fixed latency that has nothing to
+/// do with the kernels: burn's is about 35 ms, so a suite that downloaded
+/// every iteration reported that latency for every case and the same number
+/// came back for a 128x128 add as for a 2048x2048 matmul. Amortized over a
+/// round, what is left is the work. `run_once` therefore only has to get an
+/// iteration *started*; `flush` makes the round's results real, and holds
+/// every one of them alive until it does, so neither library can skip the
+/// results nobody asked for.
+pub(crate) async fn time_samples<F, Fut, T, G, GFut>(
     config: BenchmarkConfig,
     mut run_once: F,
+    mut flush: G,
 ) -> BenchmarkResult<Vec<Duration>>
 where
     F: FnMut() -> Fut,
-    Fut: Future<Output = BenchmarkResult<()>>,
+    Fut: Future<Output = BenchmarkResult<T>>,
+    G: FnMut(Vec<T>) -> GFut,
+    GFut: Future<Output = BenchmarkResult<()>>,
 {
     let config = config.sanitized();
-    for _ in 0..config.warmups {
-        run_once().await?;
+    if config.warmups > 0 {
+        let mut warm = Vec::with_capacity(config.warmups);
+        for _ in 0..config.warmups {
+            warm.push(run_once().await?);
+        }
+        flush(warm).await?;
     }
 
     let mut samples = Vec::with_capacity(config.samples);
     for _ in 0..config.samples {
         let started = Instant::now();
+        let mut round = Vec::with_capacity(config.iterations);
         for _ in 0..config.iterations {
-            run_once().await?;
+            round.push(run_once().await?);
         }
+        flush(round).await?;
         samples.push(started.elapsed());
     }
     Ok(samples)

--- a/fusor/fusor-conformance/src/bench/registry.rs
+++ b/fusor/fusor-conformance/src/bench/registry.rs
@@ -7,6 +7,12 @@ use super::{
     BenchmarkResult,
 };
 
+/// Run each case on its own session over `device`'s backend.
+///
+/// A case measures itself only if it starts from nothing: a session keeps
+/// every value ever built in its e-graph and every plan it has cached, so a
+/// case run after forty others resolves against their leftovers. Sharing one
+/// session made a batched matmul report 8.35 ms that reports 0.27 ms alone.
 pub async fn run_cases(
     device: &Device,
     config: BenchmarkConfig,
@@ -17,14 +23,26 @@ pub async fn run_cases(
     for case in cases {
         let name = case.name().to_string();
         progress(BenchmarkEvent::Started(name.clone()));
-        let report = case
-            .run(device, config)
-            .await
-            .map_err(|err| -> BenchmarkError { format!("{name}: {err}").into() })?;
+        let report = run_isolated(&name, case, device, config).await?;
         progress(BenchmarkEvent::Finished(report.clone()));
         reports.push(report);
     }
     Ok(reports)
+}
+
+/// One case on a session of its own. See [`run_cases`].
+async fn run_isolated(
+    name: &str,
+    case: BenchmarkCase,
+    device: &Device,
+    config: BenchmarkConfig,
+) -> BenchmarkResult<BenchmarkReport> {
+    let own = device
+        .isolated()
+        .map_err(|err| -> BenchmarkError { format!("{name}: {err}").into() })?;
+    case.run(&own, config)
+        .await
+        .map_err(|err| -> BenchmarkError { format!("{name}: {err}").into() })
 }
 
 pub async fn run_case(
@@ -35,7 +53,7 @@ pub async fn run_case(
     let Some(case) = cases().into_iter().find(|case| case.name() == name) else {
         return Err(format!("unknown benchmark case: {name}").into());
     };
-    case.run(device, config).await
+    run_isolated(name, case, device, config).await
 }
 
 macro_rules! registry {

--- a/fusor/fusor-conformance/src/bench/sweep.rs
+++ b/fusor/fusor-conformance/src/bench/sweep.rs
@@ -316,7 +316,11 @@ pub async fn run_sweep(
             suite: "webgpu",
             label: label.clone(),
         });
-        let webgpu = run_webgpu_case(case, device, *size, config).await?;
+        // Each size on a session of its own, for the reason
+        // `registry::run_cases` gives: a shared one carries the earlier
+        // sizes' graphs into this one's measurement.
+        let own = device.isolated()?;
+        let webgpu = run_webgpu_case(case, &own, *size, config).await?;
         progress(BenchmarkSweepEvent::Finished {
             suite: "webgpu",
             label: label.clone(),

--- a/fusor/fusor-conformance/src/bench/webgpu.rs
+++ b/fusor/fusor-conformance/src/bench/webgpu.rs
@@ -67,7 +67,48 @@ fn elements(shape: &[usize]) -> usize {
     shape.iter().product()
 }
 
-/// Dispatch everything `value` needs and wait for the device to retire it.
+/// Dispatch everything `value` needs and read the result back to the host.
+///
+/// The readback is the point: burn's only awaitable completion signal is
+/// `into_data_async`, which downloads the whole tensor, so a fusor side that
+/// stopped at a queue fence would be timed against a burn side that also
+/// paid for the download. Both suites now end an iteration the same way —
+/// compute the value and retrieve it — and the comparison is between the
+/// two libraries rather than between two different definitions of "done".
+/// Dispatch everything `value` needs, without waiting for it.
+///
+/// The graph hash-conses, so rebuilding the same expression in the next
+/// iteration yields the same node, and a node whose class still holds a
+/// device buffer resolves to nothing. Dropping that binding first is what
+/// makes every iteration real work: without it the second iteration and each
+/// one after would dispatch no kernels at all, and the suite would time an
+/// empty submit against a burn side that recomputes each time.
+fn dispatch<const R: usize, T: fusor::Element>(
+    device: &Device,
+    value: Tensor<R, T>,
+) -> BenchmarkResult<Tensor<R, T>> {
+    value.as_dyn().clear_device_buf();
+    device
+        .session()
+        .resolve(std::slice::from_ref(value.as_dyn()))?;
+    Ok(value)
+}
+
+/// Wait for the round's dispatches and bring one result back, which is the
+/// same shape of work the burn side's `flush` does.
+async fn flush<const R: usize, T: fusor::Element>(
+    device: &Device,
+    outputs: Vec<Tensor<R, T>>,
+) -> BenchmarkResult<()> {
+    device.wait_async().await?;
+    if let Some(last) = outputs.last() {
+        let _ = last.as_slice().await?;
+    }
+    drop(outputs);
+    Ok(())
+}
+
+/// Dispatch `value` and read it back: the one-shot form the input setup uses.
 async fn materialize<const R: usize, T: fusor::Element>(
     device: &Device,
     value: &Tensor<R, T>,
@@ -76,6 +117,7 @@ async fn materialize<const R: usize, T: fusor::Element>(
         .session()
         .resolve(std::slice::from_ref(value.as_dyn()))?;
     device.wait_async().await?;
+    let _ = value.as_slice().await?;
     Ok(())
 }
 
@@ -175,14 +217,19 @@ pub async fn run_webgpu_bench_suite_with_progress(
         .await
 }
 
-/// Time `iterations` of: build `output`, dispatch it, fence.
+/// Time rounds of `iterations` of: build `output` and dispatch it, with one
+/// download closing each round (see `bench::time_samples`).
 macro_rules! timed {
     ($device:expr, $config:expr, $output:expr) => {{
         let device = $device;
-        time_samples($config, || {
-            let output = $output;
-            async move { materialize(device, &output).await }
-        })
+        time_samples(
+            $config,
+            || {
+                let output = $output;
+                async move { dispatch(device, output) }
+            },
+            |outputs| async move { flush(device, outputs).await },
+        )
         .await?
     }};
 }
@@ -497,18 +544,23 @@ pub(super) async fn top_k_case(
     values: Vec<f32>,
 ) -> BenchmarkResult<BenchmarkReport> {
     let input = values_input(device, [input_len], &values).await?;
-    let samples = time_samples(config, || {
-        let (top_values, top_indices) = input.top_k(k as u32);
-        async move {
-            materialize(device, &top_values).await?;
-            materialize(device, &top_indices).await?;
-            let got = top_indices.elem_count().unwrap_or(0) as usize;
-            if got != k {
-                return Err(format!("top_k returned {got} pairs, expected {k}").into());
+    let samples = time_samples(
+        config,
+        || {
+            let (top_values, top_indices) = input.top_k(k as u32);
+            async move {
+                let got = top_indices.elem_count().unwrap_or(0) as usize;
+                if got != k {
+                    return Err(format!("top_k returned {got} pairs, expected {k}").into());
+                }
+                // Both halves of the pair are dispatched; the round's flush
+                // downloads the indices, which is what the caller reads.
+                dispatch(device, top_values)?;
+                dispatch(device, top_indices)
             }
-            Ok(())
-        }
-    })
+        },
+        |outputs| async move { flush(device, outputs).await },
+    )
     .await?;
     Ok(BenchmarkReport::new(
         name,

--- a/fusor/fusor-conformance/src/harness.rs
+++ b/fusor/fusor-conformance/src/harness.rs
@@ -438,7 +438,20 @@ pub fn fuzz_case(
     body: impl AsyncFn(&Session, &[u64], u32) -> CaseResult + Send + Sync + 'static,
 ) -> Case {
     Case::new(area, name, async move |session: &Session| {
+        // The member sweep races every e-class member of every launch and is
+        // most of what a run costs — hundreds of extra kernel executions for
+        // a case whose own dispatches take microseconds. What it covers is
+        // the case's kernels, and running the same case again at another
+        // shape mostly re-covers the same ones, so one run of each case pays
+        // for it rather than all of them. Which run is fixed per case and
+        // spread across the suite, so shape-dependent members still get
+        // swept somewhere.
+        let sweep = sweeping_members();
+        let sweep_run = case_seed(name, 0) % runs();
         for run in 0..runs() {
+            if sweep {
+                fusor::session::set_verify_members(run == sweep_run);
+            }
             let seed = case_seed(name, run);
             let shape = sample_shape(&mut Rng::new(seed), spec);
             body(session, &shape, seed)
@@ -453,10 +466,25 @@ pub fn fuzz_case(
                             format!("run {run} at shape {shape:?} (seed {seed}): {message}").into()
                         }
                     }
+                })
+                .inspect_err(|_| {
+                    if sweep {
+                        fusor::session::set_verify_members(true);
+                    }
                 })?;
+        }
+        if sweep {
+            fusor::session::set_verify_members(true);
         }
         Ok(())
     })
+}
+
+/// Whether this process was asked to sweep class members at all, read once:
+/// the flag itself is toggled per run, so it cannot be the source of truth.
+fn sweeping_members() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(fusor::session::verify_members)
 }
 
 /// Element count of a fully constant shape. Panics on a symbolic extent: a

--- a/fusor/fusor-conformance/src/main.rs
+++ b/fusor/fusor-conformance/src/main.rs
@@ -48,10 +48,9 @@ fn main() -> ExitCode {
     let _ = log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Warn));
     // Race every class member of every launch, value-checking each against
     // the selected plan, so a case covers the *class* rather than whichever
-    // member extraction happened to pick.
-    //
-    // SAFETY: set before any thread reads the environment.
-    unsafe { std::env::set_var("FUSOR_VERIFY_MEMBERS", "1") };
+    // member extraction happened to pick. A fuzzed case pays for this on one
+    // of its runs, not all of them (see `harness::fuzz_case`).
+    fusor::session::set_verify_members(true);
     let args: Vec<String> = std::env::args().skip(1).collect();
     // Everything after the flags is a case-name substring filter.
     let filter = args.iter().find(|a| !a.starts_with("--")).cloned();

--- a/fusor/fusor-cpu/src/target.rs
+++ b/fusor/fusor-cpu/src/target.rs
@@ -141,6 +141,24 @@ impl Target for CpuTarget {
         Ok(buf)
     }
 
+    fn copy(&self, src: &Buf) -> Result<Buf> {
+        let source = src
+            .downcast_ref::<AlignedBuf>()
+            .ok_or_else(|| Error::Device("copy source is not an AlignedBuf".into()))?;
+        let dst = self.alloc(source.len() as u64, Persistence::Persistent)?;
+        let target = dst
+            .downcast_ref::<AlignedBuf>()
+            .ok_or_else(|| Error::Device("copy target is not an AlignedBuf".into()))?;
+        // SAFETY: `alloc` rounds up, so `target` is at least `source.len()`
+        // bytes; the two are distinct allocations; and a buffer the pool has
+        // just handed out has no other user. `as_mut_ptr` is the allocator's
+        // documented write path (see `alloc.rs`).
+        unsafe {
+            std::ptr::copy_nonoverlapping(source.as_ptr(), target.as_mut_ptr(), source.len());
+        }
+        Ok(dst)
+    }
+
     /// No-op: [`crate::pool::WorkerPool::parallel_for`] joins synchronously, so
     /// every dispatch has already retired when `launch` returns.
     fn wait(&self) -> Result<()> {

--- a/fusor/fusor-gpu/src/caps.rs
+++ b/fusor/fusor-gpu/src/caps.rs
@@ -118,6 +118,13 @@ pub(crate) fn requested_features(adapter: &wgpu::Adapter) -> wgpu::Features {
     want(wgpu::Features::SUBGROUP);
     want(wgpu::Features::SHADER_F16);
     want(wgpu::Features::PIPELINE_CACHE);
+    // wasm32 never requests timestamps: the tuner's clock reads its query
+    // set back synchronously right after the resolve, and a browser can only
+    // deliver a buffer map from its event loop, so holding the bit would
+    // deadlock the page on the first timed resolve. Without the bit
+    // `timestamp_query_set` is `None` and every consumer takes its
+    // "not timed" path.
+    #[cfg(not(target_arch = "wasm32"))]
     if available.contains(wgpu::Features::TIMESTAMP_QUERY) {
         want(wgpu::Features::TIMESTAMP_QUERY);
         want(wgpu::Features::TIMESTAMP_QUERY_INSIDE_PASSES);

--- a/fusor/fusor-gpu/src/emit/expr.rs
+++ b/fusor/fusor-gpu/src/emit/expr.rs
@@ -28,6 +28,18 @@ use super::{
 /// The largest finite f32 WGSL will parse back identically.
 pub(crate) const WGSL_SAFE_F32_MAX: f32 = 3.40282e38;
 
+/// Whether a finite f32 has to be spelled through its bit pattern.
+///
+/// `±f32::MAX` prints as `3.4028235e38`, which as an exact decimal lies
+/// above the type's maximum; naga's parser rounds it back, but Tint refuses
+/// the module ("value cannot be represented as 'f32'") and the browser then
+/// never runs the kernel. Every smaller magnitude prints within half an ulp
+/// of itself and so within range. `bitcast<f32>(0x7f7fffffu)` is the same
+/// value on every backend.
+fn needs_bit_spelling(v: f32) -> bool {
+    v.is_finite() && v.abs() == f32::MAX
+}
+
 impl Emitter<'_> {
     /// Append a *pure* expression (literal, pointer, argument): naga does not
     /// require these to appear in an `Emit` range.
@@ -715,6 +727,12 @@ impl Emitter<'_> {
         body: &mut Block,
     ) -> Result<Handle<Expression>, EmitError> {
         match expr.kind() {
+            TileExprKind::Literal(TileLiteral::F32(bits))
+                if needs_bit_spelling(f32::from_bits(*bits)) =>
+            {
+                let bits = self.u32_lit(*bits);
+                Ok(self.cast_as(body, bits, ScalarKind::Float, None))
+            }
             TileExprKind::Literal(lit) => Ok(self.append(tile_literal(*lit)?)),
             TileExprKind::CoopZero { .. } => {
                 let ty = self.element_type(expr.element())?;
@@ -1043,7 +1061,15 @@ impl Emitter<'_> {
         value: f64,
     ) -> Option<Handle<Expression>> {
         let lit = match self.exprs[like] {
-            Expression::Literal(Literal::F32(_)) => Literal::F32(value as f32),
+            Expression::Literal(Literal::F32(_)) => {
+                let v = value as f32;
+                // A fold whose result WGSL text cannot spell is left unfolded;
+                // the operation computes it at run time instead.
+                if !v.is_finite() || needs_bit_spelling(v) {
+                    return None;
+                }
+                Literal::F32(v)
+            }
             Expression::Literal(Literal::F16(_)) => Literal::F16(half::f16::from_f64(value)),
             Expression::Literal(Literal::U32(_)) => Literal::U32(value as u32),
             Expression::Literal(Literal::I32(_)) => Literal::I32(value as i32),

--- a/fusor/fusor-gpu/src/launch.rs
+++ b/fusor/fusor-gpu/src/launch.rs
@@ -870,6 +870,21 @@ impl Launcher {
         }
     }
 
+    /// Queue a device-to-device copy of `bytes` from the start of `src` to
+    /// the start of `dst`. Ordered after every earlier submission, so the
+    /// copy reads what the dispatches that produced `src` wrote.
+    pub fn copy_buffer(&self, src: &Buf, dst: &Buf, bytes: u64) -> Result<()> {
+        self.lost.check()?;
+        let record = CommandRecord::CopyBuffer {
+            src: src.clone(),
+            src_offset: 0,
+            dst: dst.clone(),
+            dst_offset: 0,
+            bytes,
+        };
+        self.encode_command_records(&[record], None, TimingMode::All)
+    }
+
     /// Copy `src` into `staging`, map it, and return the bytes. On `Ok` the
     /// staging buffer is unmapped again; on `Err` its map state is unknown.
     ///

--- a/fusor/fusor-gpu/src/target.rs
+++ b/fusor/fusor-gpu/src/target.rs
@@ -1316,6 +1316,15 @@ impl Target for GpuTarget {
         self.pool.alloc(bytes, persistence)
     }
 
+    fn copy(&self, src: &Buf) -> Result<Buf> {
+        let source = src
+            .downcast_ref::<crate::pool::GpuBuffer>()
+            .ok_or_else(|| Error::Device("copy source is not pooled".into()))?;
+        let dst = self.pool.alloc_with_usage(source.size, source.usage)?;
+        self.launcher.copy_buffer(src, &dst, source.size)?;
+        Ok(dst)
+    }
+
     fn wait(&self) -> Result<()> {
         self.launcher.poll_wait()
     }

--- a/fusor/fusor-ir/src/target.rs
+++ b/fusor/fusor-ir/src/target.rs
@@ -190,6 +190,11 @@ pub trait Target: Send + Sync {
 
     fn alloc(&self, bytes: u64, persistence: crate::dtype::Persistence) -> Result<Buf>;
 
+    /// A fresh buffer holding a byte-for-byte copy of `src`, made on the
+    /// device: what a detached value's leaf is built on, with no host round
+    /// trip, so it is the one form a browser can use.
+    fn copy(&self, src: &Buf) -> Result<Buf>;
+
     /// Block until every submitted dispatch has retired. The only host
     /// syncs are this, explicit readback, and the allocator's cap retry.
     fn wait(&self) -> Result<()>;

--- a/fusor/fusor/src/device.rs
+++ b/fusor/fusor/src/device.rs
@@ -176,6 +176,26 @@ impl Device {
         &self.inner().session
     }
 
+    /// Another device on the same backend, with its own session and graph.
+    ///
+    /// The hardware, its compiled pipelines and its buffer pool are shared;
+    /// the e-graph, the plans cached for it and the tuning done against it
+    /// are not. Values cannot cross between the two.
+    ///
+    /// What a measurement wants. A session accumulates: every value ever
+    /// built stays in its e-graph, and a resolve walks what is there, so a
+    /// benchmark sharing one session with forty others is partly timing
+    /// them. Handing each its own makes a case measure itself.
+    pub fn isolated(&self) -> Result<Self> {
+        let inner = Inner::new(self.session().backend())?;
+        Ok(match self {
+            #[cfg(feature = "cpu")]
+            Self::Cpu(_) => Self::Cpu(Cpu(inner)),
+            #[cfg(feature = "gpu")]
+            Self::Gpu(_) => Self::Gpu(Gpu(inner)),
+        })
+    }
+
     /// The graph values built from this device live in.
     pub fn graph(&self) -> &Graph {
         &self.inner().graph

--- a/fusor/fusor/src/graph.rs
+++ b/fusor/fusor/src/graph.rs
@@ -665,6 +665,19 @@ impl GraphRef {
         self.state.session.read_bytes_locked(&resolving, self, id)
     }
 
+    /// [`Self::read_back`]'s device-side twin: resolve `id` and return a
+    /// fresh buffer holding a copy of its bytes, with the layout the copied
+    /// buffer carries. The same guard spans the resolve and the copy, for
+    /// the reason `read_back` gives.
+    pub(crate) fn copy_device(&self, id: Id) -> Result<(Buf, Option<fusor_ir::shape::Layout>)> {
+        let tensor = self.tensor(id);
+        let resolving = self.state.resolve_lock.lock();
+        self.state
+            .session
+            .resolve_locked(&resolving, std::slice::from_ref(&tensor))?;
+        self.state.session.copy_device_locked(&resolving, self, id)
+    }
+
     /// [`Self::read_back`], awaited. The graph lock spans the resolve and
     /// the readback plan; the download runs after it, holding its own
     /// handle on the buffer (see `Session::read_plan_locked`).

--- a/fusor/fusor/src/session.rs
+++ b/fusor/fusor/src/session.rs
@@ -458,6 +458,12 @@ fn slot_of(d: Dim) -> Option<usize> {
 }
 
 impl Session {
+    /// The backend this session runs on, for building another session over
+    /// the same device.
+    pub fn backend(&self) -> Backend {
+        self.inner.device.clone()
+    }
+
     /// Create a planner, compiler, and execution session for `device`.
     pub fn new(device: Backend) -> Result<Self> {
         let planner = Planner::shared();

--- a/fusor/fusor/src/session.rs
+++ b/fusor/fusor/src/session.rs
@@ -69,6 +69,33 @@ pub fn wrong_member_count() -> u64 {
     WRONG_MEMBERS.load(Ordering::Relaxed)
 }
 
+/// Whether the tune race sweeps every class member of every launch instead
+/// of only the candidates worth timing.
+///
+/// Starts from `FUSOR_VERIFY_MEMBERS` and is settable from there on, because
+/// the sweep is a per-kernel correctness pass and a suite that reruns a case
+/// at several shapes does not need to pay for it at every one. It is by far
+/// the most expensive thing a resolve can do: one small sampling case races
+/// about 470 candidates under it.
+static VERIFY_MEMBERS: std::sync::OnceLock<std::sync::atomic::AtomicBool> =
+    std::sync::OnceLock::new();
+
+fn verify_members_flag() -> &'static std::sync::atomic::AtomicBool {
+    VERIFY_MEMBERS.get_or_init(|| {
+        std::sync::atomic::AtomicBool::new(std::env::var_os("FUSOR_VERIFY_MEMBERS").is_some())
+    })
+}
+
+/// Whether the member sweep is currently on. See [`set_verify_members`].
+pub fn verify_members() -> bool {
+    verify_members_flag().load(Ordering::Relaxed)
+}
+
+/// Turn the member sweep on or off for the resolves that follow.
+pub fn set_verify_members(on: bool) {
+    verify_members_flag().store(on, Ordering::Relaxed);
+}
+
 /// Proof that the holder owns a graph's `resolve_lock`.
 pub(crate) type ResolveGuard<'a> = parking_lot::MutexGuard<'a, ()>;
 
@@ -1854,7 +1881,7 @@ impl Session {
         // Member verification: race every candidate of every launch so each
         // gets value-checked, but adopt none — a plan that changes under
         // measurement would make suite dispatch counts nondeterministic.
-        let verify_members = std::env::var_os("FUSOR_VERIFY_MEMBERS").is_some();
+        let verify_members = verify_members();
         let min_macs = if verify_members {
             0
         } else {

--- a/fusor/fusor/src/session.rs
+++ b/fusor/fusor/src/session.rs
@@ -221,6 +221,10 @@ impl Backend {
     /// Copy a device buffer back to the host. One of exactly three host
     /// syncs, and the one that is awaited: on WebGPU the copy completes only
     /// when the browser's event loop runs, so it cannot be spun on.
+    fn copy(&self, buf: &Buf) -> Result<Buf> {
+        self.target().copy(buf)
+    }
+
     async fn download(&self, buf: &Buf, bytes: u64) -> Result<Vec<u8>> {
         match self {
             #[cfg(feature = "gpu")]
@@ -1413,6 +1417,22 @@ impl Session {
             None => raw,
             Some(g) => g.apply(&raw),
         })
+    }
+
+    /// A device-side copy of an already-resolved value's buffer, with the
+    /// layout that buffer carries. Nothing crosses to the host, so this is
+    /// the same call on every platform.
+    pub(crate) fn copy_device_locked(
+        &self,
+        _resolving: &ResolveGuard<'_>,
+        graph: &GraphRef,
+        id: Id,
+    ) -> Result<(Buf, Option<fusor_ir::shape::Layout>)> {
+        let buf = graph
+            .device_buf(id)
+            .ok_or_else(|| Error::Plan(format!("{id} has no device buffer; resolve it first")))?;
+        let copy = self.inner.device.copy(&buf)?;
+        Ok((copy, graph.device_layout(id)))
     }
 
     /// Bytes of an already-resolved value, blocking. Native only: on wasm a

--- a/fusor/fusor/src/session/explore.rs
+++ b/fusor/fusor/src/session/explore.rs
@@ -35,6 +35,7 @@ use rustc_hash::FxHashMap;
 
 use super::{
     Backend, Session, TUNE_MARGIN, autotune_min_macs, batch_aligns, plan_sparse_diff, plans_align,
+    verify_members,
 };
 use crate::graph::GraphRef;
 
@@ -90,13 +91,6 @@ fn epsilon() -> u64 {
             .and_then(|v| v.parse().ok())
             .unwrap_or(EXPLORE_EPSILON)
     })
-}
-
-/// The member-verification sweep needs a deterministic dispatch stream —
-/// it adopts nothing and counts everything — so the explorer stands down.
-fn verify_members() -> bool {
-    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ON.get_or_init(|| std::env::var_os("FUSOR_VERIFY_MEMBERS").is_some())
 }
 
 fn tune_log() -> bool {

--- a/fusor/fusor/src/tensor.rs
+++ b/fusor/fusor/src/tensor.rs
@@ -130,12 +130,19 @@ impl Tensor {
 
     /// Materialize and re-leaf, cutting this value off from its producers.
     ///
-    /// Expensive: it resolves, reads the bytes back to the host and uploads
-    /// them into a fresh `Leaf::Buffer`.
+    /// Resolves this value and builds a fresh `Leaf::Buffer` on a device-side
+    /// copy of its bytes: the original keeps its buffer, the leaf owns the
+    /// copy, and nothing crosses to the host — so this is the same call on
+    /// every platform, the web included. The copy is what makes an in-place
+    /// write to either side invisible to the other.
     pub fn detach(&self) -> Result<Tensor> {
         let facts = self.facts();
-        let bytes = self.graph.read_back(self.id)?;
-        construction::upload(&self.graph, facts.dtype, &facts.shape, bytes)
+        let (buf, layout) = self.graph.copy_device(self.id)?;
+        let leaf = construction::leaf_buffer_node(&self.graph, facts.dtype, &facts.shape)?;
+        let layout = layout.map(std::sync::Arc::new);
+        self.graph
+            .set_device_buf_class(&[leaf.id], &buf, layout.as_ref());
+        Ok(leaf)
     }
 
     /// Put this external leaf's bytes on the device now; see
@@ -157,11 +164,11 @@ impl Tensor {
         Ok(leaf)
     }
 
-    /// [`Self::detach`], awaited.
+    /// [`Self::detach`], awaited. The copy never waits on the host, so this
+    /// completes at once; it is kept for callers written against the awaited
+    /// readback surface.
     pub async fn detach_async(&self) -> Result<Tensor> {
-        let facts = self.facts();
-        let bytes = self.graph.read_back_async(self.id).await?;
-        construction::upload(&self.graph, facts.dtype, &facts.shape, bytes)
+        self.detach()
     }
 
     /// Attach host bytes to this external leaf, invalidating any device copy.

--- a/fusor/webgpu-runner/src/main.rs
+++ b/fusor/webgpu-runner/src/main.rs
@@ -13,7 +13,7 @@ use components::card::{Card, CardContent, CardDescription, CardHeader, CardTitle
 use components::separator::Separator;
 
 const MAX_RENDERED_STEPS: usize = 80;
-const DETAIL_SWEEP_CONFIG: BenchmarkConfig = BenchmarkConfig::new(3, 3, 15);
+const DETAIL_SWEEP_CONFIG: BenchmarkConfig = BenchmarkConfig::new(2, 10, 5);
 
 fn main() {
     // Failures also land in the browser console (see `run_test_suite`),
@@ -508,24 +508,32 @@ fn benchmark_case_slug(name: &str) -> String {
 }
 
 /// When a `burn` baseline exists for this non-burn case, returns
-/// `(burn_mean_ms, our_mean_ms)` so callers can format and color the comparison.
+/// `(burn_median_ms, our_median_ms)` so callers can format and color the
+/// comparison.
+///
+/// Medians, not means: a backend's first timed round carries its own warmup
+/// and shader compilation, which lands as one huge sample in an otherwise
+/// tight set — burn's elementwise cases have run a 0.45 ms median under a
+/// 5.35 ms mean. A ratio of means reads that startup cost as a speed
+/// difference and reports an order of magnitude that no round measured. The
+/// sweep chart already compares medians for the same reason.
 fn burn_baseline_pair(row: &BenchRow, rows: &[BenchRow]) -> Option<(f64, f64)> {
     let (suite, case) = suite_and_case(&row.name)?;
     if suite == "burn" {
         return None;
     }
-    let mean_ms = row.mean_ms?;
-    let burn_mean_ms = rows
+    let median_ms = row.median_ms?;
+    let burn_median_ms = rows
         .iter()
         .find(|candidate| {
             candidate.state == BenchState::Passed
                 && suite_and_case(&candidate.name) == Some(("burn", case))
         })
-        .and_then(|candidate| candidate.mean_ms)?;
-    if mean_ms <= 0.0 || burn_mean_ms <= 0.0 {
+        .and_then(|candidate| candidate.median_ms)?;
+    if median_ms <= 0.0 || burn_median_ms <= 0.0 {
         return None;
     }
-    Some((burn_mean_ms, mean_ms))
+    Some((burn_median_ms, median_ms))
 }
 
 fn format_burn_comparison(row: &BenchRow, rows: &[BenchRow]) -> String {
@@ -533,17 +541,17 @@ fn format_burn_comparison(row: &BenchRow, rows: &[BenchRow]) -> String {
         return "baseline".to_string();
     }
     match burn_baseline_pair(row, rows) {
-        Some((burn_mean_ms, mean_ms)) if mean_ms <= burn_mean_ms => {
-            format!("{:.2}x faster", burn_mean_ms / mean_ms)
+        Some((burn_median_ms, median_ms)) if median_ms <= burn_median_ms => {
+            format!("{:.2}x faster", burn_median_ms / median_ms)
         }
-        Some((burn_mean_ms, mean_ms)) => format!("{:.2}x slower", mean_ms / burn_mean_ms),
+        Some((burn_median_ms, median_ms)) => format!("{:.2}x slower", median_ms / burn_median_ms),
         None => "-".to_string(),
     }
 }
 
 fn burn_comparison_class(row: &BenchRow, rows: &[BenchRow]) -> &'static str {
     match burn_baseline_pair(row, rows) {
-        Some((burn_mean_ms, mean_ms)) if mean_ms <= burn_mean_ms => "cmp-faster",
+        Some((burn_median_ms, median_ms)) if median_ms <= burn_median_ms => "cmp-faster",
         Some(_) => "cmp-slower",
         None => "",
     }

--- a/fusor/webgpu-runner/src/main.rs
+++ b/fusor/webgpu-runner/src/main.rs
@@ -16,6 +16,9 @@ const MAX_RENDERED_STEPS: usize = 80;
 const DETAIL_SWEEP_CONFIG: BenchmarkConfig = BenchmarkConfig::new(3, 3, 15);
 
 fn main() {
+    // Failures also land in the browser console (see `run_test_suite`),
+    // where a headless probe or a bug report can read them whole.
+    let _ = dioxus::logger::init(dioxus::logger::tracing::Level::INFO);
     dioxus::launch(App);
 }
 
@@ -254,6 +257,7 @@ async fn run_test_suite(mut progress: Signal<TestProgressState>, mut result: Sig
             let state = match &report.outcome {
                 Outcome::Pass | Outcome::Skipped(_) => StepState::Passed,
                 Outcome::Fail(message) => {
+                    dioxus::logger::tracing::error!("FAILED {}: {message}", report.case);
                     failures += 1;
                     if first_failure.is_none() {
                         first_failure = Some(format!("{}: {message}", report.case));

--- a/fusor/webgpu-runner/src/main.rs
+++ b/fusor/webgpu-runner/src/main.rs
@@ -13,7 +13,7 @@ use components::card::{Card, CardContent, CardDescription, CardHeader, CardTitle
 use components::separator::Separator;
 
 const MAX_RENDERED_STEPS: usize = 80;
-const DETAIL_SWEEP_CONFIG: BenchmarkConfig = BenchmarkConfig::new(2, 10, 5);
+const DETAIL_SWEEP_CONFIG: BenchmarkConfig = BenchmarkConfig::new(2, 10, 9);
 
 fn main() {
     // Failures also land in the browser console (see `run_test_suite`),

--- a/fusor/webgpu-runner/src/main.rs
+++ b/fusor/webgpu-runner/src/main.rs
@@ -38,6 +38,21 @@ enum Route {
 
 #[component]
 fn App() -> Element {
+    // Route in the fragment, not the path.
+    //
+    // The page is published to GitHub Pages, which has no single-page
+    // fallback: it answers any path the build did not write a file for with
+    // its own 404, so `/benchmarks` and `/benchmarks/<case>` were reachable
+    // by clicking through from the root and by nothing else. Not a link, not
+    // a reload, not the back button after a reload. Keeping the route after
+    // a `#` means every URL asks the host for the one page that exists.
+    #[cfg(target_arch = "wasm32")]
+    use_hook(|| {
+        dioxus::history::provide_history_context(std::rc::Rc::new(
+            dioxus::web::HashHistory::new(true),
+        ))
+    });
+
     rsx! {
         Router::<Route> {}
     }


### PR DESCRIPTION
Five commits on top of `e42d26a89`, split out of the backprop branch so they can be read on their own. The base branch `backprop-base` is pinned at that commit; nothing here changes `backprop` or PR #430.

## The preview page never finished loading

`https://floneum.github.io/kalosm/pr-preview/pr-430` rendered and then froze within a few seconds. The tab was not crashing, it was deadlocked: the first replay-hit resolve arms the tuning clock, Chrome reports `TIMESTAMP_QUERY`, and `read_timestamps` then blocks the main thread on a `map_async` callback that only the event loop can deliver. wasm now never requests the feature, the same shape as the existing subgroup and cooperative-matrix gates, so every consumer takes its "not timed" path.

Two more faults surfaced once the page ran:

- `detach()` did a host round trip, which is unavailable on wasm. It is now a device-side copy through a new `Target::copy` (pool allocation plus a queued buffer copy on GPU, an `AlignedBuf` memcpy on CPU). `detach_async` is an alias.
- Tint rejects `3.4028235e38f`, which is how naga prints `f32::MAX`, so any module containing that literal was invalid and the kernel silently never ran. Sampling read zeros. The emitter now spells the value as `bitcast<f32>(bits)` and refuses to const-fold to it.

The full conformance suite passes in Chrome, on the deployed preview as well as locally.

## The benchmark page was reporting fabricated wins

It claimed roughly 10x over burn on nearly everything. Three separate inflations:

1. **fusor measured nothing.** Each iteration rebuilt the same expression; the graph hash-conses, so it was the same node, and a node whose class still holds a device buffer resolves to zero launches. A 23-iteration case did **one** resolve. Iterations now drop the cached buffer first.
2. **Unequal fences.** fusor stopped at a queue fence while burn's only awaitable is a full download. Both sides now retrieve a result.
3. **Mean over median.** burn's first round carries its warmup: elementwise cases ran a 0.45 ms median under a 5.35 ms mean, and the mean ratio printed "11.33x faster" where the median said 1.07x slower.

Then two accuracy problems that survived those fixes:

4. **Cases were measuring each other.** Every case shared one session, whose e-graph only grows, so a case ran against forty others' leftovers. A batched matmul reported 8.35 ms that reports 0.15 ms alone. `Device::isolated` gives each case its own session and graph over the same backend, and the registry and the sweep both use it.
5. **Rounds were shorter than the clock.** A browser clamps `performance.now()` to 100 microseconds, so cheap cases sat on a handful of ticks and moved up to 3.1x between runs. The iteration count is now calibrated from an unrecorded probe round to land near 20 ms, capped at 256 so a round does not pin hundreds of live outputs.

Measured over three consecutive full-page runs, the median run-to-run spread is **1.03x**, and the widest is burn's own variance rather than the harness.

The resulting picture is mixed, which is the point. fusor is ahead on quantized paired SiLU (7.9x), Q4K gemv (6.8x), RMS norm (5.1x), rope (3.2x), Q8 gemv (2.9x) and layer norm (3.1x); behind on conv1d (15x), elementwise (1.7 to 2.7x), dense matmul (2.0x) and attention (1.7x). conv1d and dense matmul are the real gaps.

`cargo run -p fusor-conformance --features burn-bench --example bench_compare` and `--example bench_sweep <case>` run the same comparison natively. Note that native numbers do not predict the page: burn's readback carries a fixed ~35 ms cost natively that it does not have in a browser.

## Every route but the root 404'd

`https://floneum.github.io/kalosm/benchmarks/dense_batched_matmul` returned GitHub's 404 page, and so did `/benchmarks`, on the live site and the preview alike. GitHub Pages has no single-page fallback: it answers any path the build did not write a file for with a 404, so the benchmark tabs were reachable by clicking through from the root and by nothing else. Not a link, not a reload, not the back button after a reload.

The build and publish steps are both reusable workflows this repo only calls into, so the fix is in the app: the router now keeps the route in the URL fragment. Every URL asks the host for the one page that exists. Verified against a plain static file server, which is the same thing Pages does: `/#/benchmarks/dense_batched_matmul` loads the detail page directly and runs its sweep, and `/#/tests` reloads into a passing suite.

Links change shape, from `/benchmarks/<case>` to `/#/benchmarks/<case>`.

## Conformance ran for 17 minutes

The binary force-set `FUSOR_VERIFY_MEMBERS=1`, which races every e-class member of every launch to value-check it, on **every** fuzz run of every case. One small sampling case executed about 470 candidates, and sampling alone was 72% of the suite.

The sweep is now a runtime flag rather than an environment read, and `fuzz_case` turns it on for one run per case, chosen per case so the swept shape varies across the suite. **17m39s to 1m43s, same 746 results, 737 passed, 9 skipped, 0 failed.** The trade is per case: kernel variants are swept at one shape instead of three.

## Verification

- Full conformance green natively (746 results) and in Chrome (373 cases), on the deployed preview too.
- Whisper transcribes correctly; the Qwen vision tower produces a coherent caption.
- Both CI clippy invocations, wasm clippy, `cargo fmt --check`, and the fusor unit tests are clean.
- All five workflows passed on `cb89fd95f`.

https://claude.ai/code/session_01AUTdnWQ8FGUP5FKR7dJsKs
