### PR TITLE
Fix benchmark accuracy and make deep links work on Pages

### DIFF
--- a/fusor/fusor-conformance/src/bench/mod.rs
+++ b/fusor/fusor-conformance/src/bench/mod.rs
@@ -55,12 +55,12 @@ impl BenchmarkConfig {
 }
 
 impl Default for BenchmarkConfig {
-    /// Ten iterations to a round, because one download closes a round and
-    /// burn's costs about 35 ms however small the tensor is: at three
-    /// iterations that latency is still a third of what a cheap case
-    /// reports, and at ten it is a few percent.
+    /// The iteration count here is only calibration's starting guess (see
+    /// [`time_samples`]); nine rounds is what the reported median rests on,
+    /// which holds the run-to-run spread near ten percent for about eight
+    /// seconds of page time.
     fn default() -> Self {
-        Self::new(2, 10, 5)
+        Self::new(2, 10, 9)
     }
 }
 
@@ -81,17 +81,27 @@ pub struct BenchmarkReport {
     pub detail: String,
 }
 
+/// What one case's timed rounds produced: the rounds themselves and how many
+/// iterations each of them held, which calibration decides rather than the
+/// config (see [`time_samples`]).
+pub(crate) struct TimedRounds {
+    pub(crate) rounds: Vec<Duration>,
+    pub(crate) iterations: usize,
+}
+
 impl BenchmarkReport {
     pub(crate) fn new(
         name: impl Into<String>,
         config: BenchmarkConfig,
-        samples: Vec<Duration>,
+        timed: TimedRounds,
         detail: impl Into<String>,
     ) -> Self {
         let config = config.sanitized();
+        let iterations = timed.iterations.max(1);
+        let samples = timed.rounds;
         let mut sample_mean_ms = samples
             .iter()
-            .map(|elapsed| elapsed.as_secs_f64() * 1000.0 / config.iterations as f64)
+            .map(|elapsed| elapsed.as_secs_f64() * 1000.0 / iterations as f64)
             .collect::<Vec<_>>();
         let total_ms = samples
             .iter()
@@ -103,11 +113,11 @@ impl BenchmarkReport {
         let min_ms = sample_mean_ms.first().copied().unwrap_or(0.0);
         let max_ms = sample_mean_ms.last().copied().unwrap_or(0.0);
         let stddev_ms = stddev(&sample_mean_ms, mean_ms);
-        let total_iterations = config.iterations * config.samples;
+        let total_iterations = iterations * samples.len();
         Self {
             name: name.into(),
             warmups: config.warmups,
-            iterations: config.iterations,
+            iterations,
             samples: config.samples,
             total_iterations,
             sample_mean_ms,
@@ -192,11 +202,42 @@ impl BenchmarkCase {
 /// iteration *started*; `flush` makes the round's results real, and holds
 /// every one of them alive until it does, so neither library can skip the
 /// results nobody asked for.
+/// How long a timed round should take. A browser clamps `performance.now()`
+/// to 100 microseconds, so a round of a few hundred microseconds is only a
+/// handful of ticks and quantization alone moved these cases by 3x between
+/// runs. Twenty milliseconds is two hundred ticks, which puts the clock's
+/// contribution near a half percent.
+const TARGET_ROUND_MS: f64 = 20.0;
+
+/// Ceiling on a calibrated round. A round holds every iteration's output
+/// alive until it flushes, so the count is also how many results sit on the
+/// device at once: at a megabyte an output, a few hundred is already a few
+/// hundred megabytes. The cheapest cases hit this and settle for a shorter
+/// round, which still clears the clock by a wide margin.
+const MAX_ITERATIONS: usize = 256;
+
+/// Time `samples` rounds, each of enough iterations to outrun the clock, and
+/// close every round with one `flush`.
+///
+/// **Rounds, not iterations, are timed.** Retrieving a result costs each
+/// library a fixed latency unrelated to the kernels — burn's is about 35 ms —
+/// so a suite that downloaded every iteration reported that latency for every
+/// case, and a 128x128 add measured the same as a 2048x2048 matmul.
+///
+/// **The iteration count is calibrated, not configured.** `config.iterations`
+/// is the starting guess; one unrecorded round measures the case and the
+/// count is rescaled so a timed round lands near [`TARGET_ROUND_MS`]. Without
+/// it the cheap cases sat under the browser's timer resolution and their
+/// numbers were noise.
+///
+/// `run_once` only has to get an iteration started; `flush` makes the round's
+/// results real and holds every one of them alive until it does, so neither
+/// library can skip the results nobody asked for.
 pub(crate) async fn time_samples<F, Fut, T, G, GFut>(
     config: BenchmarkConfig,
     mut run_once: F,
     mut flush: G,
-) -> BenchmarkResult<Vec<Duration>>
+) -> BenchmarkResult<TimedRounds>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = BenchmarkResult<T>>,
@@ -204,23 +245,34 @@ where
     GFut: Future<Output = BenchmarkResult<()>>,
 {
     let config = config.sanitized();
-    if config.warmups > 0 {
-        let mut warm = Vec::with_capacity(config.warmups);
-        for _ in 0..config.warmups {
-            warm.push(run_once().await?);
+    let round = async |n: usize, run_once: &mut F, flush: &mut G| -> BenchmarkResult<Duration> {
+        let started = Instant::now();
+        let mut held = Vec::with_capacity(n);
+        for _ in 0..n {
+            held.push(run_once().await?);
         }
-        flush(warm).await?;
+        flush(held).await?;
+        Ok(started.elapsed())
+    };
+
+    for _ in 0..config.warmups {
+        round(config.iterations, &mut run_once, &mut flush).await?;
     }
 
-    let mut samples = Vec::with_capacity(config.samples);
+    // Calibrate off a round nobody records: whatever the case costs, the
+    // timed rounds should be long enough to measure.
+    let probe = round(config.iterations, &mut run_once, &mut flush).await?;
+    let per_iteration_ms = probe.as_secs_f64() * 1000.0 / config.iterations as f64;
+    let iterations = if per_iteration_ms > 0.0 {
+        ((TARGET_ROUND_MS / per_iteration_ms).ceil() as usize)
+            .clamp(config.iterations, MAX_ITERATIONS)
+    } else {
+        MAX_ITERATIONS
+    };
+
+    let mut rounds = Vec::with_capacity(config.samples);
     for _ in 0..config.samples {
-        let started = Instant::now();
-        let mut round = Vec::with_capacity(config.iterations);
-        for _ in 0..config.iterations {
-            round.push(run_once().await?);
-        }
-        flush(round).await?;
-        samples.push(started.elapsed());
+        rounds.push(round(iterations, &mut run_once, &mut flush).await?);
     }
-    Ok(samples)
+    Ok(TimedRounds { rounds, iterations })
 }

--- a/fusor/fusor-conformance/src/bench/registry.rs
+++ b/fusor/fusor-conformance/src/bench/registry.rs
@@ -7,6 +7,12 @@ use super::{
     BenchmarkResult,
 };
 
+/// Run each case on its own session over `device`'s backend.
+///
+/// A case measures itself only if it starts from nothing: a session keeps
+/// every value ever built in its e-graph and every plan it has cached, so a
+/// case run after forty others resolves against their leftovers. Sharing one
+/// session made a batched matmul report 8.35 ms that reports 0.27 ms alone.
 pub async fn run_cases(
     device: &Device,
     config: BenchmarkConfig,
@@ -17,14 +23,26 @@ pub async fn run_cases(
     for case in cases {
         let name = case.name().to_string();
         progress(BenchmarkEvent::Started(name.clone()));
-        let report = case
-            .run(device, config)
-            .await
-            .map_err(|err| -> BenchmarkError { format!("{name}: {err}").into() })?;
+        let report = run_isolated(&name, case, device, config).await?;
         progress(BenchmarkEvent::Finished(report.clone()));
         reports.push(report);
     }
     Ok(reports)
+}
+
+/// One case on a session of its own. See [`run_cases`].
+async fn run_isolated(
+    name: &str,
+    case: BenchmarkCase,
+    device: &Device,
+    config: BenchmarkConfig,
+) -> BenchmarkResult<BenchmarkReport> {
+    let own = device
+        .isolated()
+        .map_err(|err| -> BenchmarkError { format!("{name}: {err}").into() })?;
+    case.run(&own, config)
+        .await
+        .map_err(|err| -> BenchmarkError { format!("{name}: {err}").into() })
 }
 
 pub async fn run_case(
@@ -35,7 +53,7 @@ pub async fn run_case(
     let Some(case) = cases().into_iter().find(|case| case.name() == name) else {
         return Err(format!("unknown benchmark case: {name}").into());
     };
-    case.run(device, config).await
+    run_isolated(name, case, device, config).await
 }
 
 macro_rules! registry {

--- a/fusor/fusor-conformance/src/bench/sweep.rs
+++ b/fusor/fusor-conformance/src/bench/sweep.rs
@@ -316,7 +316,11 @@ pub async fn run_sweep(
             suite: "webgpu",
             label: label.clone(),
         });
-        let webgpu = run_webgpu_case(case, device, *size, config).await?;
+        // Each size on a session of its own, for the reason
+        // `registry::run_cases` gives: a shared one carries the earlier
+        // sizes' graphs into this one's measurement.
+        let own = device.isolated()?;
+        let webgpu = run_webgpu_case(case, &own, *size, config).await?;
         progress(BenchmarkSweepEvent::Finished {
             suite: "webgpu",
             label: label.clone(),

--- a/fusor/fusor/src/device.rs
+++ b/fusor/fusor/src/device.rs
@@ -176,6 +176,26 @@ impl Device {
         &self.inner().session
     }
 
+    /// Another device on the same backend, with its own session and graph.
+    ///
+    /// The hardware, its compiled pipelines and its buffer pool are shared;
+    /// the e-graph, the plans cached for it and the tuning done against it
+    /// are not. Values cannot cross between the two.
+    ///
+    /// What a measurement wants. A session accumulates: every value ever
+    /// built stays in its e-graph, and a resolve walks what is there, so a
+    /// benchmark sharing one session with forty others is partly timing
+    /// them. Handing each its own makes a case measure itself.
+    pub fn isolated(&self) -> Result<Self> {
+        let inner = Inner::new(self.session().backend())?;
+        Ok(match self {
+            #[cfg(feature = "cpu")]
+            Self::Cpu(_) => Self::Cpu(Cpu(inner)),
+            #[cfg(feature = "gpu")]
+            Self::Gpu(_) => Self::Gpu(Gpu(inner)),
+        })
+    }
+
     /// The graph values built from this device live in.
     pub fn graph(&self) -> &Graph {
         &self.inner().graph

--- a/fusor/fusor/src/session.rs
+++ b/fusor/fusor/src/session.rs
@@ -458,6 +458,12 @@ fn slot_of(d: Dim) -> Option<usize> {
 }
 
 impl Session {
+    /// The backend this session runs on, for building another session over
+    /// the same device.
+    pub fn backend(&self) -> Backend {
+        self.inner.device.clone()
+    }
+
     /// Create a planner, compiler, and execution session for `device`.
     pub fn new(device: Backend) -> Result<Self> {
         let planner = Planner::shared();

--- a/fusor/webgpu-runner/src/main.rs
+++ b/fusor/webgpu-runner/src/main.rs
@@ -13,7 +13,7 @@ use components::card::{Card, CardContent, CardDescription, CardHeader, CardTitle
 use components::separator::Separator;
 
 const MAX_RENDERED_STEPS: usize = 80;
-const DETAIL_SWEEP_CONFIG: BenchmarkConfig = BenchmarkConfig::new(2, 10, 5);
+const DETAIL_SWEEP_CONFIG: BenchmarkConfig = BenchmarkConfig::new(2, 10, 9);
 
 fn main() {
     // Failures also land in the browser console (see `run_test_suite`),

--- a/fusor/webgpu-runner/src/main.rs
+++ b/fusor/webgpu-runner/src/main.rs
@@ -38,6 +38,21 @@ enum Route {
 
 #[component]
 fn App() -> Element {
+    // Route in the fragment, not the path.
+    //
+    // The page is published to GitHub Pages, which has no single-page
+    // fallback: it answers any path the build did not write a file for with
+    // its own 404, so `/benchmarks` and `/benchmarks/<case>` were reachable
+    // by clicking through from the root and by nothing else. Not a link, not
+    // a reload, not the back button after a reload. Keeping the route after
+    // a `#` means every URL asks the host for the one page that exists.
+    #[cfg(target_arch = "wasm32")]
+    use_hook(|| {
+        dioxus::history::provide_history_context(std::rc::Rc::new(
+            dioxus::web::HashHistory::new(true),
+        ))
+    });
+
     rsx! {
         Router::<Route> {}
     }


### PR DESCRIPTION
The two commits from the backprop work that missed the #430 squash, rebased onto `main`.

## Every route but the root 404'd

`https://floneum.github.io/kalosm/benchmarks/dense_batched_matmul` returned GitHub's 404 page, and so did `/benchmarks`. GitHub Pages has no single-page fallback: it answers any path the build did not write a file for with a 404, so the benchmark tabs were reachable by clicking through from the root and by nothing else. Not a link, not a reload, not the back button after a reload.

The build and publish steps are both reusable workflows this repo only calls into, so no step here can copy `index.html` to `404.html`. The fix is in the app: the router now keeps the route in the URL fragment, so every URL asks the host for the one page that exists. Verified against a plain static file server, which behaves the same way Pages does. `/#/benchmarks/dense_batched_matmul` loads the detail page directly and runs its sweep; `/#/tests` reloads into a passing suite.

Links change shape, from `/benchmarks/<case>` to `/#/benchmarks/<case>`.

## The benchmark page was still measuring the wrong thing

Two problems, on top of the ones already fixed in #430.

**Cases were measuring each other.** Every case shared one session, and a session's e-graph only grows, so a case ran against the previous forty cases' leftovers. A batched matmul reported 8.35 ms that reports 0.15 ms when it runs alone, which is where the "19x slower than burn" headline came from. `Device::isolated` gives each case its own session and graph over the same backend, and both the registry and the sweep use it.

**Rounds were shorter than the clock.** A browser clamps `performance.now()` to 100 microseconds, so the cheap cases sat on a handful of ticks and their numbers moved by as much as 3.1x between runs. The iteration count is now calibrated from an unrecorded probe round to land near 20 ms, capped at 256 so a round does not pin hundreds of live outputs on the device.

Measured over three consecutive full-page runs, the median run-to-run spread is **1.03x**, and the widest is burn's own variance rather than the harness. The page finishes in about six seconds.

The resulting picture is mixed, which is the point. fusor is ahead on quantized paired SiLU (7.9x), Q4K gemv (6.8x), RMS norm (5.1x), rope (3.2x), Q8 gemv (2.9x) and layer norm (3.1x); behind on conv1d (15x), elementwise (1.7 to 2.7x), dense matmul (2.0x) and attention (1.7x). conv1d and dense matmul are the real gaps, and this is the first time the page has said so.

`cargo run -p fusor-conformance --features burn-bench --example bench_compare` and `--example bench_sweep <case>` run the same comparison natively. Native numbers do not predict the page: burn's readback carries a fixed ~35 ms cost natively that it does not have in a browser.

## Verification

Conformance is green natively (746 results) and in Chrome (373 cases). Both CI clippy invocations, wasm clippy, `cargo fmt --check` and the fusor unit tests are clean.

https://claude.ai/code/session_01AUTdnWQ8FGUP5FKR7dJsKs
